### PR TITLE
Update app.desktop.patch

### DIFF
--- a/app.desktop.patch
+++ b/app.desktop.patch
@@ -4,7 +4,8 @@ index fa37a93..d352644 100755
 +++ b/onlykey-app/resources/linux/app.desktop
 @@ -1,10 +1,9 @@
  [Desktop Entry]
- Version=1.5
+-Version={{version}}
++Version=1.5
  Type=Application
 -Encoding=UTF-8
  Name={{name}}

--- a/app.desktop.patch
+++ b/app.desktop.patch
@@ -4,7 +4,7 @@ index fa37a93..d352644 100755
 +++ b/onlykey-app/resources/linux/app.desktop
 @@ -1,10 +1,9 @@
  [Desktop Entry]
- Version={{version}}
+ Version=1.5
  Type=Application
 -Encoding=UTF-8
  Name={{name}}


### PR DESCRIPTION
Set Version to desktop entry specification version
"Version key does not stand for the version of the application, but for the version of the desktop entry specification to which this file complies."
[source](https://wiki.archlinux.org/title/Desktop_entries#Key_definition)